### PR TITLE
Name and correctly test Ruby feature checks

### DIFF
--- a/lib/dry/transformer/hash.rb
+++ b/lib/dry/transformer/hash.rb
@@ -4,6 +4,10 @@ require 'dry/transformer/coercions'
 
 module Dry
   module Transformer
+    USE_HASH_SLICE = Gem::Dependency.new('ruby', '>= 2.5').match?('ruby', RUBY_VERSION)
+    USE_HASH_TRANSFORM_KEYS = Gem::Dependency.new('ruby', '>= 2.5').match?('ruby', RUBY_VERSION)
+    USE_HASH_TRANSFORM_VALUES = Gem::Dependency.new('ruby', '>= 2.4').match?('ruby', RUBY_VERSION)
+
     # Transformation functions for Hash objects
     #
     # @example
@@ -20,7 +24,7 @@ module Dry
     module HashTransformations
       extend Registry
 
-      if RUBY_VERSION >= '2.5'
+      if USE_HASH_TRANSFORM_KEYS
         # Map all keys in a hash with the provided transformation function
         #
         # @example
@@ -132,7 +136,7 @@ module Dry
         end
       end
 
-      if RUBY_VERSION >= '2.4'
+      if USE_HASH_TRANSFORM_VALUES
         # Map all values in a hash using transformation function
         #
         # @example
@@ -211,7 +215,7 @@ module Dry
         Hash[hash].reject { |k, _| keys.include?(k) }
       end
 
-      if RUBY_VERSION >= '2.5'
+      if USE_HASH_SLICE
         # Accepts specified keys from a hash
         #
         # @example


### PR DESCRIPTION
This small bug fix is just to use an actual, logical version comparison rather than a simple string comparison when making determinations about features available in the current Ruby environment.

While string comparison for version checking does often work, `RUBY_VERSION >= 2.4` will return a false negative if running under a fictitious Ruby 2.10, as an example. Replacing the simple string comparison with actual, fully-fledged version comparison logic introduces very little overhead and makes the code more future-proof.

The naming I can certainly go either way on, but it makes the intent more clear in the code as to why those conditionals are being used. If you'd rather inline the checks, that's fine too, it just introduces a little more "why is this here?" when reading the code than I prefer if it's left unnamed.