### PR TITLE
Support keyword arguments for functions.

### DIFF
--- a/lib/dry/transformer/function.rb
+++ b/lib/dry/transformer/function.rb
@@ -97,8 +97,7 @@ module Dry
       #
       # @api public
       def to_ast
-        args_ast = args.map { |arg| arg.respond_to?(:to_ast) ? arg.to_ast : arg }
-        [name, args_ast]
+        [name, object_to_ast(args), object_to_ast(kwargs)]
       end
 
       # Converts a transproc to a simple proc
@@ -110,6 +109,22 @@ module Dry
           proc { |*value| fn.call(*value, *args, **kwargs) }
         else
           fn.to_proc
+        end
+      end
+
+      private
+
+      # @api private
+      def object_to_ast(object)
+        case object
+        when Array
+          object.map { |item| object_to_ast(item) }
+        when Hash
+          object.each_with_object({}) { |(key, value), hash|
+            hash[object_to_ast(key)] = object_to_ast(value)
+          }
+        else
+          object.respond_to?(:to_ast) ? object.to_ast : object
         end
       end
     end

--- a/lib/dry/transformer/function.rb
+++ b/lib/dry/transformer/function.rb
@@ -25,6 +25,13 @@ module Dry
       # @api private
       attr_reader :args
 
+      # Additional keyword arguments that will be passed to the wrapped proc
+      #
+      # @return [Hash]
+      #
+      # @api private
+      attr_reader :kwargs
+
       # @!attribute [r] name
       #
       # @return [<type] The name of the function
@@ -36,6 +43,7 @@ module Dry
       def initialize(fn, options = {})
         @fn = fn
         @args = options.fetch(:args, [])
+        @kwargs = options.fetch(:kwargs, {})
         @name = options.fetch(:name, fn)
       end
 
@@ -46,8 +54,8 @@ module Dry
       # @alias []
       #
       # @api public
-      def call(*value)
-        fn.call(*value, *args)
+      def call(*value, **additional_kwargs)
+        fn.call(*value, *args, **(kwargs).merge(additional_kwargs))
       end
       alias_method :[], :call
 
@@ -71,15 +79,15 @@ module Dry
       # @return [Function]
       #
       # @api private
-      def with(*args)
-        self.class.new(fn, name: name, args: args)
+      def with(*args, **additional_kwargs)
+        self.class.new(fn, name: name, args: args, kwargs: kwargs.merge(additional_kwargs))
       end
 
       # @api public
       def ==(other)
         return false unless other.instance_of?(self.class)
 
-        [fn, name, args] == [other.fn, other.name, other.args]
+        [fn, name, args, kwargs] == [other.fn, other.name, other.args, other.kwargs]
       end
       alias_method :eql?, :==
 
@@ -99,7 +107,7 @@ module Dry
       #
       def to_proc
         if !args.empty?
-          proc { |*value| fn.call(*value, *args) }
+          proc { |*value| fn.call(*value, *args, **kwargs) }
         else
           fn.to_proc
         end

--- a/lib/dry/transformer/pipe/class_interface.rb
+++ b/lib/dry/transformer/pipe/class_interface.rb
@@ -106,8 +106,8 @@ module Dry
         # @return [Transproc::Function]
         #
         # @api public
-        def t(fn, *args)
-          container[fn, *args]
+        def t(fn, *args, **kwargs)
+          container[fn, *args, **kwargs]
         end
       end
     end

--- a/lib/dry/transformer/registry.rb
+++ b/lib/dry/transformer/registry.rb
@@ -45,10 +45,10 @@ module Dry
       #
       # @alias :t
       #
-      def [](fn, *args)
+      def [](fn, *args, **kwargs)
         fetched = fetch(fn)
 
-        return Function.new(fetched, args: args, name: fn) unless already_wrapped?(fetched)
+        return Function.new(fetched, args: args, kwargs: kwargs, name: fn) unless already_wrapped?(fetched)
 
         args.empty? ? fetched : fetched.with(*args)
       end

--- a/spec/unit/class_transformations_spec.rb
+++ b/spec/unit/class_transformations_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Dry::Transformer::ClassTransformations do
       set_ivars = described_class.t(:set_ivars, klass)
 
       input = { name: "Jane", age: 25 }
-      output = klass.new(input)
+      output = klass.new(**input)
       result = set_ivars[input]
 
       expect(result).to eql(output)

--- a/spec/unit/class_transformations_spec.rb
+++ b/spec/unit/class_transformations_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "dry/core/equalizer"
+require "dry/equalizer"
 
 RSpec.describe Dry::Transformer::ClassTransformations do
   describe ".constructor_inject" do

--- a/spec/unit/function_spec.rb
+++ b/spec/unit/function_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe Dry::Transformer::Function do
 
       expect(f3.to_ast).to eql(
         [
-          :symbolize_keys, [],
+          :symbolize_keys, [], {},
           [
-            :rename_keys, [user_name: :name]
+            :rename_keys, [], {user_name: :name}
           ]
         ]
       )
@@ -47,12 +47,12 @@ RSpec.describe Dry::Transformer::Function do
 
       expect(f4.to_ast).to eql(
         [
-          :symbolize_keys, [],
+          :symbolize_keys, [], {},
           [
-            :rename_keys, [user_name: :name]
+            :rename_keys, [], {user_name: :name}
           ],
           [
-            :nest, [:details, [:name]]
+            :nest, [:details, [:name]], {}
           ]
         ]
       )
@@ -68,9 +68,9 @@ RSpec.describe Dry::Transformer::Function do
 
       expect(f3.to_ast).to eql(
         [
-          f1.fn, [2],
+          f1.fn, [2], {},
           [
-            f2.fn, []
+            f2.fn, [], {}
           ]
         ]
       )
@@ -83,9 +83,9 @@ RSpec.describe Dry::Transformer::Function do
       expect(f["user_name" => "Jane"]).to eql(name: "Jane")
       expect(f.to_ast).to eql(
         [
-          :symbolize_keys, [],
+          :symbolize_keys, [], {},
           [
-            :rename_keys, [user_name: :name]
+            :rename_keys, [], {user_name: :name}
           ]
         ]
       )
@@ -96,7 +96,7 @@ RSpec.describe Dry::Transformer::Function do
       fn = container.t(:to_string)
 
       expect(fn[:ok]).to eql("ok")
-      expect(fn.to_ast).to eql([:to_string, []])
+      expect(fn.to_ast).to eql([:to_string, [], {}])
     end
 
     it "plays well with functions as arguments" do
@@ -108,9 +108,25 @@ RSpec.describe Dry::Transformer::Function do
       expect(fn.to_ast).to eql(
         [
           :map_array, [
-            [:to_symbol, []]
-          ]
+            [:to_symbol, [], {}]
+          ], {}
         ]
+      )
+    end
+
+    it "plays well with keyword arguments" do
+      container = Module.new do
+        extend Dry::Transformer::Registry
+
+        def self.trim(string, limit:)
+          string[0..(limit - 1)]
+        end
+      end
+
+      fn = container[:trim, limit: 3]
+
+      expect(fn.to_ast).to eql(
+        [:trim, [], {limit: 3}]
       )
     end
   end

--- a/spec/unit/registry_spec.rb
+++ b/spec/unit/registry_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Dry::Transformer::Registry do
       def self.prefix(value, prefix)
         "#{prefix}_#{value}"
       end
+
+      def self.trim(value, limit:)
+        value[0..(limit - 1)]
+      end
     end
   end
 
@@ -30,6 +34,16 @@ RSpec.describe Dry::Transformer::Registry do
 
       it "builds a function from a method" do
         expect(transproc["qux"]).to eql "baz_qux"
+      end
+    end
+
+    context "with keyword arguments" do
+      it "passes keywords through" do
+        expect(foo[:trim]["string", limit: 3]).to eql("str")
+      end
+
+      it "works with a transproc approach" do
+        expect(foo[:trim, limit: 2]["string"]).to eql("st")
       end
     end
   end

--- a/spec/unit/store_spec.rb
+++ b/spec/unit/store_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Dry::Transformer::Store do
     it "returns false if requested proc is unknown" do
       expect(store.contain?(:bar)).to be false
     end
-  end # describe #fetch
+  end # describe #contain?
 
   describe "#register" do
     subject { new_store }
@@ -73,7 +73,7 @@ RSpec.describe Dry::Transformer::Store do
     end
   end
 
-  describe "#import", :focus do
+  describe "#import" do
     before do
       module Bar
         def self.bar

--- a/spec/unit/transformer/class_interface_spec.rb
+++ b/spec/unit/transformer/class_interface_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'ostruct'
-require 'dry/core/equalizer'
+require 'dry/equalizer'
 
 RSpec.describe Dry::Transformer do
   let(:container) { Module.new { extend Dry::Transformer::Registry } }

--- a/spec/unit/transformer/class_interface_spec.rb
+++ b/spec/unit/transformer/class_interface_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Dry::Transformer do
         map_value(:attr, t(:to_symbol))
       end
 
-      expect(transproc.new.transproc[attr: 'abc']).to eq(attr: :abc)
+      expect(transproc.new.transproc[{attr: 'abc'}]).to eq(attr: :abc)
     end
 
     it 'does not affect original transformer' do


### PR DESCRIPTION
Another Ruby 3 related patch: now that keyword arguments are no longer implicitly translated into hashes, we need to explicitly handle them as a separate argument type.

And I must be clear: I don't have a deep understanding of this gem, so I feel like the specs and code are quite possibly incomplete. Hopefully they're at least useful as a starting point. 😅