### PR TITLE
Unskip test on JRuby

### DIFF
--- a/spec/unit/store_spec.rb
+++ b/spec/unit/store_spec.rb
@@ -186,8 +186,11 @@ RSpec.describe Dry::Transformer::Store do
       end
 
       it "skips Dry::Transformer::Registry singleton methods" do
-        pending "this fails for some reason" if RUBY_ENGINE == "jruby"
-        expect(subject.methods.keys).to contain_exactly(:foo, :bar, :baz, :qux)
+        # In JRuby versions up to 10.0.3.0 refine method of Module class was incorrectly
+        # marked as public, adding to the list of methods returned by subject.method.keys.
+        # This should be fixed in JRuby 10.0.4.0 - then this special handling could be removed.
+        extra_methods = RUBY_ENGINE == "jruby" ? [:refine] : []
+        expect(subject.methods.keys).to contain_exactly(*([:foo, :bar, :baz, :qux] + extra_methods))
       end
     end
 


### PR DESCRIPTION
This is due to a bug in JRuby, but the fix is now merged. Instead of skipping the test, let's make the specific assertion for JRuby.